### PR TITLE
fix is_callable_v

### DIFF
--- a/include/eosio/vm/function_traits.hpp
+++ b/include/eosio/vm/function_traits.hpp
@@ -72,9 +72,6 @@ namespace eosio { namespace vm {
       inline constexpr U&& make_dependent(U&& u) { return static_cast<U&&>(u); }
    }
 
-   template <auto FN>
-   inline constexpr static bool is_callable_v = EOS_VM_HAS_MEMBER(AUTO_PARAM_WORKAROUND(FN), operator());
-
    template <typename F>
    constexpr bool is_callable(F&& fn) { return EOS_VM_HAS_MEMBER(fn, operator()); }
 
@@ -102,7 +99,7 @@ namespace eosio { namespace vm {
                                                                std::tuple<std::conditional_t<Decay, std::decay_t<Args>, Args>...>>;
       template <bool Decay, typename F>
       constexpr auto get_types(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (is_callable(fn))
             return get_types<Decay>(&F::operator());
          else
             return get_types<Decay>(fn);
@@ -144,7 +141,7 @@ namespace eosio { namespace vm {
       constexpr auto parameters_from_impl(R(Cls::*)(Args...)const &&) ->  pack_from_t<N, Args...>;
       template <std::size_t N, typename F>
       constexpr auto parameters_from_impl(F&& fn) {
-         if constexpr (is_callable_v<decltype(fn)>)
+         if constexpr (is_callable(fn))
             return parameters_from_impl<N>(&F::operator());
          else
             return parameters_from_impl<N>(fn);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This PR fixes the problem to call a template function having auto template parameter with types instead of values. This prevents the code to be compiled with clang++ version 12 and later. 

Resolves #3 

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
