### PR TITLE
Remove -Wall warnings

### DIFF
--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -285,7 +285,7 @@ namespace eosio { namespace vm {
          // Calling execute() with no `args` (i.e. `execute(host_type,jit_visitor,uint32_t)`) results in a "statement has no
          // effect [-Werror=unused-value]" warning on this line. Dissable warning.
          native_value args_raw[] = { transform_arg( static_cast<Args&&>(args))... };
-#pragma GCC diagnostic push
+#pragma GCC diagnostic pop
 
          try {
             if (func_index < _mod.get_imported_functions_size()) {

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -268,6 +268,11 @@ namespace eosio { namespace vm {
          get_operand_stack().eat(0);
       }
 
+// Calling execute() with no `args` (i.e. `execute(host_type,jit_visitor,uint32_t)`) results in a "statement has no effect
+// [-Werror=unused-value]" warning. Dissable for this function.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+
       template <typename... Args>
       inline std::optional<operand_stack_elem> execute(host_type* host, jit_visitor, uint32_t func_index, Args... args) {
          auto saved_host = _host;
@@ -332,6 +337,10 @@ namespace eosio { namespace vm {
          }
          __builtin_unreachable();
       }
+
+// Re-enable unused value warning.
+#pragma GCC diagnostic push
+
 
 #ifdef __x86_64__
       int backtrace(void** out, int count, void* uc) const {

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -268,11 +268,6 @@ namespace eosio { namespace vm {
          get_operand_stack().eat(0);
       }
 
-// Calling execute() with no `args` (i.e. `execute(host_type,jit_visitor,uint32_t)`) results in a "statement has no effect
-// [-Werror=unused-value]" warning. Dissable for this function.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-value"
-
       template <typename... Args>
       inline std::optional<operand_stack_elem> execute(host_type* host, jit_visitor, uint32_t func_index, Args... args) {
          auto saved_host = _host;
@@ -284,7 +279,13 @@ namespace eosio { namespace vm {
          const func_type& ft = _mod.get_function_type(func_index);
          this->type_check_args(ft, static_cast<Args&&>(args)...);
          native_value result;
-         native_value args_raw[] = { transform_arg(static_cast<Args&&>(args))... };
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+         // Calling execute() with no `args` (i.e. `execute(host_type,jit_visitor,uint32_t)`) results in a "statement has no
+         // effect [-Werror=unused-value]" warning on this line. Dissable warning.
+         native_value args_raw[] = { transform_arg( static_cast<Args&&>(args))... };
+#pragma GCC diagnostic push
 
          try {
             if (func_index < _mod.get_imported_functions_size()) {
@@ -337,10 +338,6 @@ namespace eosio { namespace vm {
          }
          __builtin_unreachable();
       }
-
-// Re-enable unused value warning.
-#pragma GCC diagnostic push
-
 
 #ifdef __x86_64__
       int backtrace(void** out, int count, void* uc) const {


### PR DESCRIPTION
Remove warnings generated with -Wall. This will eventually allow us to enforce building with -Werror which can provide for better overall code quality.

Calling execute() with no `args` (i.e. `execute(host_type,jit_visitor,uint32_t)`) results in a "statement has no effect [-Werror=unused-value]" warning. Dissable `unused-value` for this function.
