### PR TITLE
store wasm globals in execution context such that a single parsed module can be shared by multiple threads

### DIFF
--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -66,6 +66,7 @@ namespace eosio { namespace vm {
       void construct(host_t* host=nullptr) {
          mod.finalize();
          ctx.set_wasm_allocator(memory_alloc);
+         ctx.initialize_globals();
          if constexpr (!std::is_same_v<HostFunctions, std::nullptr_t>)
             HostFunctions::resolve(mod);
          // FIXME: should not hard code knowledge of null_backend here

--- a/include/eosio/vm/exceptions.hpp
+++ b/include/eosio/vm/exceptions.hpp
@@ -41,6 +41,7 @@ namespace eosio { namespace vm {
    DECLARE_EXCEPTION( guarded_ptr_exception,             4010000, "pointer out of bounds" )
    DECLARE_EXCEPTION( timeout_exception,                 4010001, "timeout" )
    DECLARE_EXCEPTION( wasm_exit_exception,               4010002, "exit" )
+   DECLARE_EXCEPTION( wasm_globals_oob_exception,        4010003, "globals index out of bounds" )
    DECLARE_EXCEPTION( span_exception,                    4020000, "span exception" )
    DECLARE_EXCEPTION( profile_exception,                 4030000, "profile exception" )
 }} // eosio::vm

--- a/include/eosio/vm/exceptions.hpp
+++ b/include/eosio/vm/exceptions.hpp
@@ -41,7 +41,6 @@ namespace eosio { namespace vm {
    DECLARE_EXCEPTION( guarded_ptr_exception,             4010000, "pointer out of bounds" )
    DECLARE_EXCEPTION( timeout_exception,                 4010001, "timeout" )
    DECLARE_EXCEPTION( wasm_exit_exception,               4010002, "exit" )
-   DECLARE_EXCEPTION( wasm_globals_oob_exception,        4010003, "globals index out of bounds" )
    DECLARE_EXCEPTION( span_exception,                    4020000, "span exception" )
    DECLARE_EXCEPTION( profile_exception,                 4030000, "profile exception" )
 }} // eosio::vm

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -87,6 +87,12 @@ namespace eosio { namespace vm {
       Derived& derived() { return static_cast<Derived&>(*this); }
       execution_context_base(module& m) : _mod(m) {}
 
+      inline void initialize_globals() {
+         for (uint32_t i = 0; i < _mod.globals.size(); i++) {
+            _globals.emplace_back(_mod.globals[i].init);
+         }
+      }
+
       inline int32_t grow_linear_memory(int32_t pages) {
          const int32_t sz = _wasm_alloc->get_current_page();
          if (pages < 0) {
@@ -146,8 +152,9 @@ namespace eosio { namespace vm {
 
          // reset the mutable globals
          for (uint32_t i = 0; i < _mod.globals.size(); i++) {
-            if (_mod.globals[i].type.mutability)
-               _mod.globals[i].current = _mod.globals[i].init;
+            if (_mod.globals[i].type.mutability) {
+               _globals[i] = _mod.globals[i].init;
+            }
          }
       }
 
@@ -193,6 +200,7 @@ namespace eosio { namespace vm {
       detail::host_invoker_t<Host>    _rhf;
       std::error_code                 _error_code;
       operand_stack                   _os;
+      std::vector<init_expr>          _globals;
    };
 
    struct jit_visitor { template<typename T> jit_visitor(T&&) {} };
@@ -226,6 +234,7 @@ namespace eosio { namespace vm {
       using base_type::get_operand_stack;
       using base_type::linear_memory;
       using base_type::get_interface;
+      using base_type::_globals;
 
       jit_execution_context(module& m, std::uint32_t max_call_depth) : base_type(m), _remaining_call_depth(max_call_depth) {}
 
@@ -404,6 +413,38 @@ namespace eosio { namespace vm {
       static constexpr bool async_backtrace() { return EnableBacktrace; }
 #endif
 
+      inline int32_t get_global_i32(uint32_t index) {
+         return _globals[index].value.i32;
+      }
+
+      inline int64_t get_global_i64(uint32_t index) {
+         return _globals[index].value.i64;
+      }
+
+      inline uint32_t get_global_f32(uint32_t index) {
+         return _globals[index].value.f32;
+      }
+
+      inline uint64_t get_global_f64(uint32_t index) {
+         return _globals[index].value.f64;
+      }
+
+      inline void set_global_i32(uint32_t index, int32_t value) {
+         _globals[index].value.i32 = value;
+      }
+
+      inline void set_global_i64(uint32_t index, int64_t value) {
+         _globals[index].value.i64 = value;
+      }
+
+      inline void set_global_f32(uint32_t index, uint32_t value) {
+          _globals[index].value.f32 = value;
+      }
+
+      inline void set_global_f64(uint32_t index, uint64_t value) {
+         _globals[index].value.f64 = value;
+      }
+
    protected:
 
       template<typename T>
@@ -501,6 +542,7 @@ namespace eosio { namespace vm {
       using base_type::get_operand_stack;
       using base_type::linear_memory;
       using base_type::get_interface;
+      using base_type::_globals;
 
       execution_context(module& m, uint32_t max_call_depth)
        : base_type(m), _base_allocator{max_call_depth*sizeof(activation_frame)},
@@ -585,10 +627,10 @@ namespace eosio { namespace vm {
          EOS_VM_ASSERT(index < _mod.globals.size(), wasm_interpreter_exception, "global index out of range");
          const auto& gl = _mod.globals[index];
          switch (gl.type.content_type) {
-            case types::i32: return i32_const_t{ *(uint32_t*)&gl.current.value.i32 };
-            case types::i64: return i64_const_t{ *(uint64_t*)&gl.current.value.i64 };
-            case types::f32: return f32_const_t{ gl.current.value.f32 };
-            case types::f64: return f64_const_t{ gl.current.value.f64 };
+            case types::i32: return i32_const_t{ _globals[index].value.i32 };
+            case types::i64: return i64_const_t{ _globals[index].value.i64 };
+            case types::f32: return f32_const_t{ _globals[index].value.f32 };
+            case types::f64: return f64_const_t{ _globals[index].value.f64 };
             default: throw wasm_interpreter_exception{ "invalid global type" };
          }
       }
@@ -600,22 +642,22 @@ namespace eosio { namespace vm {
          visit(overloaded{ [&](const i32_const_t& i) {
                                   EOS_VM_ASSERT(gl.type.content_type == types::i32, wasm_interpreter_exception,
                                                 "expected i32 global type");
-                                  gl.current.value.i32 = i.data.ui;
+                                  _globals[index].value.i32 = i.data.ui;
                                },
                                 [&](const i64_const_t& i) {
                                    EOS_VM_ASSERT(gl.type.content_type == types::i64, wasm_interpreter_exception,
                                                  "expected i64 global type");
-                                   gl.current.value.i64 = i.data.ui;
+                                   _globals[index].value.i64 = i.data.ui;
                                 },
                                 [&](const f32_const_t& f) {
                                    EOS_VM_ASSERT(gl.type.content_type == types::f32, wasm_interpreter_exception,
                                                  "expected f32 global type");
-                                   gl.current.value.f32 = f.data.ui;
+                                   _globals[index].value.f32 = f.data.ui;
                                 },
                                 [&](const f64_const_t& f) {
                                    EOS_VM_ASSERT(gl.type.content_type == types::f64, wasm_interpreter_exception,
                                                  "expected f64 global type");
-                                   gl.current.value.f64 = f.data.ui;
+                                   _globals[index].value.f64 = f.data.ui;
                                 },
                                 [](auto) { throw wasm_interpreter_exception{ "invalid global type" }; } },
                     el);

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -88,6 +88,8 @@ namespace eosio { namespace vm {
       execution_context_base(module& m) : _mod(m) {}
 
       inline void initialize_globals() {
+         EOS_VM_ASSERT(_globals.empty(), wasm_memory_exception, "initialize_globals called on non-empty _globals");
+         _globals.reserve(_mod.globals.size());
          for (uint32_t i = 0; i < _mod.globals.size(); i++) {
             _globals.emplace_back(_mod.globals[i].init);
          }
@@ -151,6 +153,7 @@ namespace eosio { namespace vm {
          }
 
          // reset the mutable globals
+         EOS_VM_ASSERT(_globals.size() == _mod.globals.size(), wasm_memory_exception, "number of globals in execution_context not equall to the one in module");
          for (uint32_t i = 0; i < _mod.globals.size(); i++) {
             if (_mod.globals[i].type.mutability) {
                _globals[i] = _mod.globals[i].init;
@@ -414,34 +417,42 @@ namespace eosio { namespace vm {
 #endif
 
       inline int32_t get_global_i32(uint32_t index) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_i32");
          return _globals[index].value.i32;
       }
 
       inline int64_t get_global_i64(uint32_t index) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_i64");
          return _globals[index].value.i64;
       }
 
       inline uint32_t get_global_f32(uint32_t index) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_f32");
          return _globals[index].value.f32;
       }
 
       inline uint64_t get_global_f64(uint32_t index) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_f64");
          return _globals[index].value.f64;
       }
 
       inline void set_global_i32(uint32_t index, int32_t value) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_i32");
          _globals[index].value.i32 = value;
       }
 
       inline void set_global_i64(uint32_t index, int64_t value) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_i64");
          _globals[index].value.i64 = value;
       }
 
       inline void set_global_f32(uint32_t index, uint32_t value) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_f32");
           _globals[index].value.f32 = value;
       }
 
       inline void set_global_f64(uint32_t index, uint64_t value) {
+         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_f64");
          _globals[index].value.f64 = value;
       }
 

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -417,42 +417,34 @@ namespace eosio { namespace vm {
 #endif
 
       inline int32_t get_global_i32(uint32_t index) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_i32");
          return _globals[index].value.i32;
       }
 
       inline int64_t get_global_i64(uint32_t index) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_i64");
          return _globals[index].value.i64;
       }
 
       inline uint32_t get_global_f32(uint32_t index) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_f32");
          return _globals[index].value.f32;
       }
 
       inline uint64_t get_global_f64(uint32_t index) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in get_global_f64");
          return _globals[index].value.f64;
       }
 
       inline void set_global_i32(uint32_t index, int32_t value) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_i32");
          _globals[index].value.i32 = value;
       }
 
       inline void set_global_i64(uint32_t index, int64_t value) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_i64");
          _globals[index].value.i64 = value;
       }
 
       inline void set_global_f32(uint32_t index, uint32_t value) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_f32");
           _globals[index].value.f32 = value;
       }
 
       inline void set_global_f64(uint32_t index, uint64_t value) {
-         EOS_VM_ASSERT(index < _globals.size(), wasm_globals_oob_exception, "global index out of range in set_global_f64");
          _globals[index].value.f64 = value;
       }
 

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -640,6 +640,7 @@ namespace eosio { namespace vm {
 
       inline void set_global(uint32_t index, const operand_stack_elem& el) {
          EOS_VM_ASSERT(index < _mod.globals.size(), wasm_interpreter_exception, "global index out of range");
+         EOS_VM_ASSERT(index < _globals.size(), wasm_interpreter_exception, "index for _globals out of range");
          auto& gl = _mod.globals[index];
          EOS_VM_ASSERT(gl.type.mutability, wasm_interpreter_exception, "global is not mutable");
          visit(overloaded{ [&](const i32_const_t& i) {

--- a/include/eosio/vm/parser.hpp
+++ b/include/eosio/vm/parser.hpp
@@ -469,7 +469,6 @@ namespace eosio { namespace vm {
          if(gv.type.mutability)
             on_mutable_global(ct);
          parse_init_expr(code, gv.init, ct);
-         gv.current = gv.init;
       }
 
       void parse_memory_type(wasm_code_ptr& code, memory_type& mt) {

--- a/include/eosio/vm/types.hpp
+++ b/include/eosio/vm/types.hpp
@@ -74,7 +74,6 @@ namespace eosio { namespace vm {
    struct global_variable {
       global_type type;
       init_expr   init;
-      init_expr   current;
    };
 
    struct table_type {


### PR DESCRIPTION
Resolves https://github.com/AntelopeIO/eos-vm/issues/7.
A part of https://github.com/eosnetworkfoundation/product/issues/149.

Currently globals are stored in a compiled module. This prevents the module from being shared by multiple execution threads, as multiple threads can modify the same global. To enable the same compiled module to be shared,
globals are moved out of module and into the execution context.

This opens possibilities for further parallelism and memory reduction for cached instantiated modules.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
