### PR TITLE
Parse WASM code only once for JIT

### DIFF
--- a/include/eosio/vm/allocator.hpp
+++ b/include/eosio/vm/allocator.hpp
@@ -294,35 +294,22 @@ namespace eosio { namespace vm {
          // uses mmap for big memory allocation
          _base = (char*)mmap(NULL, max_memory_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
          EOS_VM_ASSERT(_base != MAP_FAILED, wasm_bad_alloc, "failed to mmap for default memory.");
-         _mmap_used = true;
          _capacity = max_memory_size;
       }
 
       // size in bytes
-      void use_fixed_memory(bool is_jit, size_t size) {
+      void use_fixed_memory(size_t size) {
          EOS_VM_ASSERT(0 < size && size <= max_memory_size, wasm_bad_alloc, "Too large or 0 fixed memory size");
          EOS_VM_ASSERT(_base == nullptr, wasm_bad_alloc, "Fixed memory already allocated");
 
-         _is_jit = is_jit;
-         if (_is_jit) {
-            _base = (char*)std::calloc(size, sizeof(char));
-            EOS_VM_ASSERT(_base != nullptr, wasm_bad_alloc, "malloc in use_fixed_memory failed.");
-            _mmap_used = false;
-         } else {
-            _base = (char*)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-            EOS_VM_ASSERT(_base != MAP_FAILED, wasm_bad_alloc, "mmap in use_fixed_memoryfailed.");
-            _mmap_used = true;
-         }
+         _base = (char*)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+         EOS_VM_ASSERT(_base != MAP_FAILED, wasm_bad_alloc, "mmap in use_fixed_memoryfailed.");
          _capacity = size;
       }
 
       ~growable_allocator() {
          if (_base != nullptr) {
-            if (_mmap_used) {
-                munmap(_base, _capacity);
-            } else {
-                std::free(_base);
-            }
+            munmap(_base, _capacity);
          }
          if (_is_jit && _code_base) {
             jit_allocator::instance().free(_code_base);
@@ -373,11 +360,6 @@ namespace eosio { namespace vm {
          }
       }
 
-      void set_code_base_and_size(char* code_base, size_t code_size) {
-         _code_base = code_base;
-         _code_size = code_size;
-      }
-
       // Sets protection on code pages to allow them to be executed.
       void enable_code(bool is_jit) {
          mprotect(_code_base, _code_size, is_jit?PROT_EXEC:(PROT_READ|PROT_WRITE));
@@ -409,17 +391,30 @@ namespace eosio { namespace vm {
        * Finalize the memory by unmapping any excess pages, this means that the allocator will no longer grow
        */
       void finalize() {
-         if(_mmap_used && _capacity != _offset) {
+         if(_capacity != _offset) {
             std::size_t final_size = align_to_page(_offset);
             if (final_size < _capacity) { // final_size can grow to _capacity after align_to_page.
                                           // make sure no 0 size passed to munmap
                EOS_VM_ASSERT(munmap(_base + final_size, _capacity - final_size) == 0, wasm_bad_alloc, "failed to finalize growable_allocator");
+               _capacity = _offset = final_size;
+               if (final_size == 0) {
+                  // _base became invalid after munmap if final_size is 0 so
+                  // set it to nullptr to avoid being used
+                  _base = nullptr;
+               }
             }
-            _capacity = _offset = final_size;
          }
       }
 
       void free() { EOS_VM_ASSERT(false, wasm_bad_alloc, "unimplemented"); }
+
+      void release_base_memory()
+      {
+         if (_base != nullptr) {
+            EOS_VM_ASSERT(munmap(_base, _capacity) == 0, wasm_bad_alloc, "failed to release base memory");
+            _base = nullptr;
+         }
+      }
 
       void reset() { _offset = 0; }
 
@@ -430,7 +425,6 @@ namespace eosio { namespace vm {
       char*    _code_base             = nullptr;
       size_t   _code_size             = 0;
       bool     _is_jit                = false;
-      bool     _mmap_used             = false;
    };
 
    template <typename T>

--- a/include/eosio/vm/allocator.hpp
+++ b/include/eosio/vm/allocator.hpp
@@ -303,7 +303,7 @@ namespace eosio { namespace vm {
          EOS_VM_ASSERT(_base == nullptr, wasm_bad_alloc, "Fixed memory already allocated");
 
          _base = (char*)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-         EOS_VM_ASSERT(_base != MAP_FAILED, wasm_bad_alloc, "mmap in use_fixed_memoryfailed.");
+         EOS_VM_ASSERT(_base != MAP_FAILED, wasm_bad_alloc, "mmap in use_fixed_memory failed.");
          _capacity = size;
       }
 

--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -68,8 +68,11 @@ namespace eosio { namespace vm {
          ctx.set_wasm_allocator(memory_alloc);
          // Now data required by JIT is finalized; create JIT module
          // such that memory used in parsing can be released.
-         if (Impl::is_jit) {
+         if constexpr (Impl::is_jit) {
             mod.make_jit_module();
+
+            // Important. Release the memory used by parsing.
+            mod.allocator.release_base_memory();
          }
          ctx.initialize_globals();
          if constexpr (!std::is_same_v<HostFunctions, std::nullptr_t>)

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -85,25 +85,44 @@ namespace eosio { namespace vm {
       using host_type  = detail::host_type_t<Host>;
     public:
       Derived& derived() { return static_cast<Derived&>(*this); }
-      execution_context_base(module& m) : _mod(m) {}
+      execution_context_base(module& m, bool is_jit) : _mod(m), _is_jit(is_jit)  {}
 
       inline void initialize_globals() {
+         if (_is_jit) {
+            return initialize_globals_impl(*_mod.jit_mod);
+         }
+         else {
+            return initialize_globals_impl(_mod);
+         }
+      }
+
+      template<typename Module>
+      inline void initialize_globals_impl(const Module& mod) {
          EOS_VM_ASSERT(_globals.empty(), wasm_memory_exception, "initialize_globals called on non-empty _globals");
-         _globals.reserve(_mod.globals.size());
-         for (uint32_t i = 0; i < _mod.globals.size(); i++) {
-            _globals.emplace_back(_mod.globals[i].init);
+         _globals.reserve(mod.globals.size());
+         for (uint32_t i = 0; i < mod.globals.size(); i++) {
+            _globals.emplace_back(mod.globals[i].init);
          }
       }
 
       inline int32_t grow_linear_memory(int32_t pages) {
+         if (_is_jit) {
+            return grow_linear_memory_impl(*_mod.jit_mod, pages);
+         } else {
+            return grow_linear_memory_impl(_mod, pages);
+         }
+      }
+
+      template<typename Module>
+      inline int32_t grow_linear_memory_impl(const Module& mod, int32_t pages) {
          const int32_t sz = _wasm_alloc->get_current_page();
          if (pages < 0) {
             if (sz + pages < 0)
                return -1;
             _wasm_alloc->free<char>(-pages);
          } else {
-            if (!_mod.memories.size() || _max_pages - sz < static_cast<uint32_t>(pages) ||
-                (_mod.memories[0].limits.flags && (static_cast<int32_t>(_mod.memories[0].limits.maximum) - sz < pages)))
+            if (!mod.memories.size() || _max_pages - sz < static_cast<uint32_t>(pages) ||
+                (mod.memories[0].limits.flags && (static_cast<int32_t>(mod.memories[0].limits.maximum) - sz < pages)))
                return -1;
             _wasm_alloc->alloc<char>(pages);
          }
@@ -128,7 +147,8 @@ namespace eosio { namespace vm {
 
       inline std::error_code get_error_code() const { return _error_code; }
 
-      inline void reset() {
+      template<typename Module>
+      inline void reset(Module& mod) {
          EOS_VM_ASSERT(_mod.error == nullptr, wasm_interpreter_exception, _mod.error);
 
          // Reset the capacity of underlying memory used by operand stack if it is
@@ -136,27 +156,27 @@ namespace eosio { namespace vm {
          _os.reset_capacity();
 
          _linear_memory = _wasm_alloc->get_base_ptr<char>();
-         if(_mod.memories.size()) {
-            EOS_VM_ASSERT(_mod.memories[0].limits.initial <= _max_pages, wasm_bad_alloc, "Cannot allocate initial linear memory.");
-            _wasm_alloc->reset(_mod.memories[0].limits.initial);
+         if(mod.memories.size()) {
+            EOS_VM_ASSERT(mod.memories[0].limits.initial <= _max_pages, wasm_bad_alloc, "Cannot allocate initial linear memory.");
+            _wasm_alloc->reset(mod.memories[0].limits.initial);
          } else
             _wasm_alloc->reset();
 
-         for (uint32_t i = 0; i < _mod.data.size(); i++) {
-            const auto& data_seg = _mod.data[i];
+         for (uint32_t i = 0; i < mod.data.size(); i++) {
+            const auto& data_seg = mod.data[i];
             uint32_t offset = data_seg.offset.value.i32; // force to unsigned
-            auto available_memory =  _mod.memories[0].limits.initial * static_cast<uint64_t>(page_size);
+            auto available_memory =  mod.memories[0].limits.initial * static_cast<uint64_t>(page_size);
             auto required_memory = static_cast<uint64_t>(offset) + data_seg.data.size();
             EOS_VM_ASSERT(required_memory <= available_memory, wasm_memory_exception, "data out of range");
             auto addr = _linear_memory + offset;
-            memcpy((char*)(addr), data_seg.data.raw(), data_seg.data.size());
+            memcpy((char*)(addr), data_seg.data.data(), data_seg.data.size());
          }
 
          // reset the mutable globals
-         EOS_VM_ASSERT(_globals.size() == _mod.globals.size(), wasm_memory_exception, "number of globals in execution_context not equall to the one in module");
-         for (uint32_t i = 0; i < _mod.globals.size(); i++) {
-            if (_mod.globals[i].type.mutability) {
-               _globals[i] = _mod.globals[i].init;
+         EOS_VM_ASSERT(_globals.size() == mod.globals.size(), wasm_memory_exception, "number of globals in execution_context not equall to the one in module");
+         for (uint32_t i = 0; i < mod.globals.size(); i++) {
+            if (mod.globals[i].type.mutability) {
+               _globals[i] = mod.globals[i].init;
             }
          }
       }
@@ -176,8 +196,8 @@ namespace eosio { namespace vm {
 
     protected:
 
-      template<typename... Args>
-      static void type_check_args(const func_type& ft, Args&&...) {
+      template<typename Func_type, typename... Args>
+      static void type_check_args(const Func_type& ft, Args&&...) {
          EOS_VM_ASSERT(sizeof...(Args) == ft.param_types.size(), wasm_interpreter_exception, "wrong number of arguments");
          uint32_t i = 0;
          EOS_VM_ASSERT((... && (to_wasm_type_v<detail::type_converter_t<Host>, Args> == ft.param_types.at(i++))), wasm_interpreter_exception, "unexpected argument type");
@@ -204,6 +224,7 @@ namespace eosio { namespace vm {
       std::error_code                 _error_code;
       operand_stack                   _os;
       std::vector<init_expr>          _globals;
+      bool                            _is_jit = false;
    };
 
    struct jit_visitor { template<typename T> jit_visitor(T&&) {} };
@@ -212,7 +233,7 @@ namespace eosio { namespace vm {
    class null_execution_context : public execution_context_base<null_execution_context<Host>, Host> {
       using base_type = execution_context_base<null_execution_context<Host>, Host>;
    public:
-      null_execution_context(module& m, std::uint32_t max_call_depth) : base_type(m) {}
+      null_execution_context(module& m, std::uint32_t max_call_depth) : base_type(m, false) {}
    };
 
    template<bool EnableBacktrace>
@@ -239,14 +260,14 @@ namespace eosio { namespace vm {
       using base_type::get_interface;
       using base_type::_globals;
 
-      jit_execution_context(module& m, std::uint32_t max_call_depth) : base_type(m), _remaining_call_depth(max_call_depth) {}
+      jit_execution_context(module& m, std::uint32_t max_call_depth) : base_type(m, true), _remaining_call_depth(max_call_depth) {}
 
       void set_max_call_depth(std::uint32_t max_call_depth) {
          _remaining_call_depth = max_call_depth;
       }
 
       inline native_value call_host_function(native_value* stack, uint32_t index) {
-         const auto& ft = _mod.get_function_type(index);
+         const auto& ft = _mod.jit_mod->get_function_type(index);
          uint32_t num_params = ft.param_types.size();
 #ifndef NDEBUG
          uint32_t original_operands = get_operand_stack().size();
@@ -260,7 +281,7 @@ namespace eosio { namespace vm {
              default: assert(!"Unexpected type in param_types.");
             }
          }
-         _rhf(_host, get_interface(), _mod.import_functions[index]);
+         _rhf(_host, get_interface(), _mod.jit_mod->import_functions[index]);
          native_value result{uint64_t{0}};
          // guarantee that the junk bits are zero, to avoid problems.
          auto set_result = [&result](auto val) { std::memcpy(&result, &val, sizeof(val)); };
@@ -280,7 +301,7 @@ namespace eosio { namespace vm {
       }
 
       inline void reset() {
-         base_type::reset();
+         base_type::reset(*(_mod.jit_mod));
          get_operand_stack().eat(0);
       }
 
@@ -292,7 +313,7 @@ namespace eosio { namespace vm {
 
          _host = host;
 
-         const func_type& ft = _mod.get_function_type(func_index);
+         const auto& ft = _mod.jit_mod->get_function_type(func_index);
          this->type_check_args(ft, static_cast<Args&&>(args)...);
          native_value result;
 
@@ -304,7 +325,7 @@ namespace eosio { namespace vm {
 #pragma GCC diagnostic pop
 
          try {
-            if (func_index < _mod.get_imported_functions_size()) {
+            if (func_index < _mod.jit_mod->get_imported_functions_size()) {
                std::reverse(args_raw + 0, args_raw + sizeof...(Args));
                result = call_host_function(args_raw, func_index);
             } else {
@@ -317,7 +338,7 @@ namespace eosio { namespace vm {
                if(stack) {
                   stack = static_cast<char*>(stack) - 24;
                }
-               auto fn = reinterpret_cast<native_value (*)(void*, void*)>(_mod.code[func_index - _mod.get_imported_functions_size()].jit_code_offset + _mod.allocator._code_base);
+               auto fn = reinterpret_cast<native_value (*)(void*, void*)>(_mod.jit_mod->code_offset[func_index - _mod.jit_mod->get_imported_functions_size()] + _mod.allocator._code_base);
 
                if constexpr(EnableBacktrace) {
                   sigset_t block_mask;
@@ -548,7 +569,7 @@ namespace eosio { namespace vm {
       using base_type::_globals;
 
       execution_context(module& m, uint32_t max_call_depth)
-       : base_type(m), _base_allocator{max_call_depth*sizeof(activation_frame)},
+       : base_type(m, false), _base_allocator{max_call_depth*sizeof(activation_frame)},
          _as{max_call_depth, _base_allocator}, _halt(exit_t{}) {}
 
       void set_max_call_depth(uint32_t max_call_depth) {
@@ -712,7 +733,7 @@ namespace eosio { namespace vm {
       }
 
       inline void reset() {
-         base_type::reset();
+         base_type::reset(_mod);
          _state = execution_state{};
          get_operand_stack().eat(_state.os_index);
          _as.eat(_state.as_index);

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -337,7 +337,7 @@ namespace eosio { namespace vm {
                if(stack) {
                   stack = static_cast<char*>(stack) - 24;
                }
-               auto fn = reinterpret_cast<native_value (*)(void*, void*)>(_mod.jit_mod->code_offset[func_index - _mod.jit_mod->get_imported_functions_size()] + _mod.allocator._code_base);
+               auto fn = reinterpret_cast<native_value (*)(void*, void*)>(_mod.jit_mod->jit_code_offset[func_index - _mod.jit_mod->get_imported_functions_size()] + _mod.allocator._code_base);
 
                if constexpr(EnableBacktrace) {
                   sigset_t block_mask;

--- a/include/eosio/vm/host_function.hpp
+++ b/include/eosio/vm/host_function.hpp
@@ -368,9 +368,6 @@ namespace eosio { namespace vm {
          lhs.ret.size() == rhs.return_count &&
          (lhs.ret.size() == 0 || lhs.ret[0] == rhs.return_type);
    }
-   inline bool operator==(const func_type& lhs, const host_function& rhs) {
-      return rhs == lhs;
-   }
 
    template<typename TC, typename Args, std::size_t... Is>
    void get_args(value_type*& out, std::index_sequence<Is...>) {

--- a/include/eosio/vm/types.hpp
+++ b/include/eosio/vm/types.hpp
@@ -309,9 +309,6 @@ namespace eosio { namespace vm {
          if (import_functions.size() > 0) {
             jit_mod->import_functions.assign(import_functions.data(), import_functions.data() + import_functions.size());
          }
-
-         // Important. Release the memory used during parsing.
-         allocator.release_base_memory();
       }
 
       void finalize() {

--- a/include/eosio/vm/vector.hpp
+++ b/include/eosio/vm/vector.hpp
@@ -75,6 +75,7 @@ namespace eosio { namespace vm {
             constexpr inline T& operator[] (size_t i) const { return at(i); }
             constexpr inline T& operator[] (size_t i) { return at(i); }
             constexpr inline T* raw() const { return _data; }
+            constexpr inline T* data() const { return _data; }
             constexpr inline size_t size() const { return _size; }
             constexpr inline void set( T* data, size_t size, size_t index=-1 ) { _size = size; _data = data; _index = index == -1 ? size - 1 : index; }
             constexpr inline void copy( T* data, size_t size ) {

--- a/tests/allocator_tests.cpp
+++ b/tests/allocator_tests.cpp
@@ -110,38 +110,38 @@ TEST_CASE("Testing use_default_memory", "[growable_allocator]") {
 
    growable_allocator alloc3;
    alloc3.use_default_memory();
-   // can allocate as much as researved memory
+   // can allocate as much as reserved memory
    alloc3.alloc<char>(growable_allocator::max_memory_size);
-   // cannot allocate more than researved memory
+   // cannot allocate more than reserved memory
    CHECK_THROWS_AS(alloc3.alloc<char>(1), wasm_bad_alloc);
 }
 
 TEST_CASE("Testing use_fixed_memory", "[growable_allocator]") {
    growable_allocator alloc(1024);
    // use_fixed_memory cannot be called when memory is already allocated by constructor
-   CHECK_THROWS_AS(alloc.use_fixed_memory(false, 4096), wasm_bad_alloc);
+   CHECK_THROWS_AS(alloc.use_fixed_memory(4096), wasm_bad_alloc);
 
    growable_allocator alloc1;
-   alloc1.use_fixed_memory(true, 1024);
+   alloc1.use_fixed_memory(1024);
    // use_fixed_memory cannot be called multiple times
-   CHECK_THROWS_AS(alloc1.use_fixed_memory(true, 1024), wasm_bad_alloc);
+   CHECK_THROWS_AS(alloc1.use_fixed_memory(1024), wasm_bad_alloc);
 
    growable_allocator alloc2;
    // fixed_memory size cannot be 0
-   CHECK_THROWS_AS(alloc2.use_fixed_memory(true, 0), wasm_bad_alloc);
+   CHECK_THROWS_AS(alloc2.use_fixed_memory(0), wasm_bad_alloc);
    // fixed_memory size cannot be too big
-   CHECK_THROWS_AS(alloc2.use_fixed_memory(true, growable_allocator::max_memory_size + 1), wasm_bad_alloc);
+   CHECK_THROWS_AS(alloc2.use_fixed_memory(growable_allocator::max_memory_size + 1), wasm_bad_alloc);
    // fixed_memory size can be growable_allocator::max_memory_size
-   alloc2.use_fixed_memory(true, growable_allocator::max_memory_size);
+   alloc2.use_fixed_memory(growable_allocator::max_memory_size);
 
    growable_allocator alloc3;
    // reserved 1024 bytes
-   alloc3.use_fixed_memory(true, 1024);
-   // can allocate less than researved memory
+   alloc3.use_fixed_memory(1024);
+   // can allocate less than reserved memory
    alloc3.alloc<char>(1000);
-   // can allocate equal to researved memory ( 1000+24 == 1024)
+   // can allocate equal to reserved memory ( 1000+24 == 1024)
    alloc3.alloc<char>(24);
-   // cannot allocate more than researved memory ( 1000+24+1 > 1024)
+   // cannot allocate more than reserved memory ( 1000+24+1 > 1024)
    CHECK_THROWS_AS(alloc3.alloc<char>(1), wasm_bad_alloc);
 }
 
@@ -149,10 +149,10 @@ TEST_CASE("Testing mixed use_fixed_memory and alloc2.use_default_memory", "[grow
    growable_allocator alloc1;
    alloc1.use_default_memory();
    // use_fixed_memory and use_fixed_memory cannot be mixed
-   CHECK_THROWS_AS(alloc1.use_fixed_memory(true, 1024), wasm_bad_alloc);
+   CHECK_THROWS_AS(alloc1.use_fixed_memory(1024), wasm_bad_alloc);
 
    growable_allocator alloc2;
-   alloc2.use_fixed_memory(true, 1024);
+   alloc2.use_fixed_memory(1024);
    // use_fixed_memory and use_default_memory cannot be mixed
    CHECK_THROWS_AS(alloc2.use_default_memory(), wasm_bad_alloc);
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
Currently, to prevent the number of memory mappings from growing, WASM code is parsed twice.

This PR parses WASM code only once for JIT. The solution is that after the first parsing, data required by JIT execution is saved in regular C++ vectors for later use, and the memory (acquired by `mmap`) used by the first parsing is released. This is made possible by  https://github.com/AntelopeIO/eos-vm/pull/16, which moves globals out from the mmapped memory.

Resolve https://github.com/AntelopeIO/eos-vm/issues/17

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
