### PR TITLE
Use a single execution context per wasm interface (per thread) instead of per contract

### DIFF
--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -135,7 +135,6 @@ namespace eosio { namespace vm {
             // delete only if the context was created by the backend
             delete ctx;
          }
-         ctx = nullptr;
       }
 
       module& parse_module(wasm_code& code, const Options& options) {
@@ -338,7 +337,7 @@ namespace eosio { namespace vm {
       DebugInfo       debug;
       context_t*      ctx = nullptr;
       bool            exec_ctx_created_by_backend = true; // true if execution context is created by backend (legacy behavior), false if provided by users (Leap uses this)
-      uint32_t        initial_max_call_depth;
-      uint32_t        initial_max_pages;
+      uint32_t        initial_max_call_depth = 0;
+      uint32_t        initial_max_pages = 0;
    };
 }} // namespace eosio::vm

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -174,7 +174,7 @@ namespace eosio { namespace vm {
             memcpy((char*)(addr), data_seg.data.data(), data_seg.data.size());
          }
 
-         // Globals are different from contract to contract.
+         // Globals can be different from one WASM code to another.
          // Need to clear _globals at the start of an execution.
          _globals.clear();
          _globals.reserve(mod.globals.size());
@@ -555,7 +555,7 @@ namespace eosio { namespace vm {
 #endif
 
       host_type * _host = nullptr;
-      uint32_t _remaining_call_depth;
+      uint32_t _remaining_call_depth = 0;
    };
 
    template <typename Host>

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -175,7 +175,7 @@ namespace eosio { namespace vm {
          }
 
          // Globals are different from contract to contract.
-         // Need to clear _globals in execution context.
+         // Need to clear _globals at the start of an execution.
          _globals.clear();
          _globals.reserve(mod.globals.size());
          for (uint32_t i = 0; i < mod.globals.size(); i++) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
A part of https://github.com/eosnetworkfoundation/product/issues/149.

Currently an execution context is created in a `backend` object for each contract, and cached (inside the backend) in `wasm_instantiation_cache` in the wasm interface object per thread. This wastes physical memory and prevents a single compiled WASM contract code shared across threads.

This PR provides an option to decouple execution context from backend, while keeps the existing behavior for backward compatibility. 

Resolves https://github.com/AntelopeIO/leap/issues/1456.


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
