### PR TITLE
remove usage of deprecated `ATOMIC_VAR_INIT`

### DIFF
--- a/include/eosio/vm/profile.hpp
+++ b/include/eosio/vm/profile.hpp
@@ -341,7 +341,7 @@ struct scoped_profile {
 #else
 
 __attribute__((visibility("default")))
-inline thread_local std::atomic<profile_data*> per_thread_profile_data = ATOMIC_VAR_INIT(nullptr);
+inline thread_local std::atomic<profile_data*> per_thread_profile_data{nullptr};
 
 inline void profile_handler(int sig, siginfo_t* info, void* uc) {
    static_assert(std::atomic<profile_data*>::is_always_lock_free);

--- a/include/eosio/vm/signals.hpp
+++ b/include/eosio/vm/signals.hpp
@@ -14,7 +14,7 @@ namespace eosio { namespace vm {
 
    // Fixes a duplicate symbol build issue when building with `-fvisibility=hidden`
    __attribute__((visibility("default")))
-   inline thread_local std::atomic<sigjmp_buf*> signal_dest = ATOMIC_VAR_INIT(nullptr);
+   inline thread_local std::atomic<sigjmp_buf*> signal_dest{nullptr};
 
    // Fixes a duplicate symbol build issue when building with `-fvisibility=hidden`
    __attribute__((visibility("default")))


### PR DESCRIPTION
`ATOMIC_VAR_INIT` is deprecated in c++20.. not seeing any reason really need it here anyways..