### PR TITLE
make signal handler less greedy: only handle signals from expected memory ranges

### DIFF
--- a/include/eosio/vm/allocator.hpp
+++ b/include/eosio/vm/allocator.hpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <map>
 #include <set>
+#include <span>
 #include <memory>
 #include <mutex>
 #include <utility>

--- a/include/eosio/vm/allocator.hpp
+++ b/include/eosio/vm/allocator.hpp
@@ -372,6 +372,8 @@ namespace eosio { namespace vm {
 
       const void* get_code_start() const { return _code_base; }
 
+      std::span<std::byte> get_code_span() const {return {(std::byte*)_code_base, _code_size};}
+
       /* different semantics than free,
        * the memory must be at the end of the most recently allocated block.
        */
@@ -524,5 +526,7 @@ namespace eosio { namespace vm {
       inline T* create_pointer(uint32_t offset) { return reinterpret_cast<T*>(raw + offset); }
       inline int32_t get_current_page() const { return page; }
       bool is_in_region(char* p) { return p >= raw && p < raw + max_memory; }
+
+      std::span<std::byte> get_span() const {return {(std::byte*)raw, max_memory};}
    };
 }} // namespace eosio::vm

--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -358,11 +358,11 @@ namespace eosio { namespace vm {
 
                   vm::invoke_with_signal_handler([&]() {
                      result = execute<sizeof...(Args)>(args_raw, fn, this, base_type::linear_memory(), stack);
-                  }, &handle_signal);
+                  }, &handle_signal, {_mod->allocator.get_code_span(),  base_type::get_wasm_allocator()->get_span()});
                } else {
                   vm::invoke_with_signal_handler([&]() {
                      result = execute<sizeof...(Args)>(args_raw, fn, this, base_type::linear_memory(), stack);
-                  }, &handle_signal);
+                  }, &handle_signal, {_mod->allocator.get_code_span(),  base_type::get_wasm_allocator()->get_span()});
                }
             }
          } catch(wasm_exit_exception&) {
@@ -800,7 +800,7 @@ namespace eosio { namespace vm {
             setup_locals(func_index);
             vm::invoke_with_signal_handler([&]() {
                execute(visitor);
-            }, &handle_signal);
+            }, &handle_signal, {_mod->allocator.get_code_span(),  base_type::get_wasm_allocator()->get_span()});
          }
 
          if (_mod->get_function_type(func_index).return_count && !_state.exiting) {

--- a/include/eosio/vm/signals.hpp
+++ b/include/eosio/vm/signals.hpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <exception>
 #include <utility>
+#include <span>
 #include <signal.h>
 #include <setjmp.h>
 

--- a/include/eosio/vm/signals.hpp
+++ b/include/eosio/vm/signals.hpp
@@ -16,6 +16,9 @@ namespace eosio { namespace vm {
    __attribute__((visibility("default")))
    inline thread_local std::atomic<sigjmp_buf*> signal_dest{nullptr};
 
+   __attribute__((visibility("default")))
+   inline thread_local std::vector<std::span<std::byte>> protected_memory_ranges;
+
    // Fixes a duplicate symbol build issue when building with `-fvisibility=hidden`
    __attribute__((visibility("default")))
    inline thread_local std::exception_ptr saved_exception{nullptr};
@@ -25,7 +28,20 @@ namespace eosio { namespace vm {
 
    inline void signal_handler(int sig, siginfo_t* info, void* uap) {
       sigjmp_buf* dest = std::atomic_load(&signal_dest);
-      if (dest) {
+
+      auto in_protected_range = [&]() {
+         //empty protection list means legacy catch-all behavior; useful for some of the old tests
+         if(protected_memory_ranges.empty())
+            return true;
+
+         for(const std::span<std::byte>& range : protected_memory_ranges) {
+            if(info->si_addr >= range.data() && info->si_addr < range.data() + range.size())
+               return true;
+         }
+         return false;
+      };
+
+      if (dest && in_protected_range()) {
          siglongjmp(*dest, sig);
       } else {
          struct sigaction* prev_action;
@@ -98,7 +114,9 @@ namespace eosio { namespace vm {
       sigaddset(&sa.sa_mask, SIGPROF);
       sa.sa_flags = SA_NODEFER | SA_SIGINFO;
       sigaction(SIGSEGV, &sa, &prev_signal_handler<SIGSEGV>);
+#ifndef __linux__
       sigaction(SIGBUS, &sa, &prev_signal_handler<SIGBUS>);
+#endif
       sigaction(SIGFPE, &sa, &prev_signal_handler<SIGFPE>);
    }
 
@@ -114,16 +132,17 @@ namespace eosio { namespace vm {
    /// with non-trivial destructors, then it must mask the relevant signals
    /// during the lifetime of these objects or the behavior is undefined.
    ///
-   /// signals handled: SIGSEGV, SIGBUS, SIGFPE
+   /// signals handled: SIGSEGV, SIGBUS (except on Linux), SIGFPE
    ///
    // Make this noinline to prevent possible corruption of the caller's local variables.
    // It's unlikely, but I'm not sure that it can definitely be ruled out if both
    // this and f are inlined and f modifies locals from the caller.
    template<typename F, typename E>
-   [[gnu::noinline]] auto invoke_with_signal_handler(F&& f, E&& e) {
+   [[gnu::noinline]] auto invoke_with_signal_handler(F&& f, E&& e, const std::vector<std::span<std::byte>>& protect_ranges) {
       setup_signal_handler();
       sigjmp_buf dest;
       sigjmp_buf* volatile old_signal_handler = nullptr;
+      protected_memory_ranges = protect_ranges;
       int sig;
       if((sig = sigsetjmp(dest, 1)) == 0) {
          // Note: Cannot use RAII, as non-trivial destructors w/ longjmp

--- a/tests/signals_tests.cpp
+++ b/tests/signals_tests.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Testing signals", "[invoke_with_signal_handler]") {
          std::raise(SIGSEGV);
       }, [](int sig) {
          throw test_exception{};
-      });
+      }, {});
    } catch(test_exception&) {
       okay = true;
    }
@@ -25,7 +25,7 @@ TEST_CASE("Testing signals", "[invoke_with_signal_handler]") {
 TEST_CASE("Testing throw", "[signal_handler_throw]") {
    CHECK_THROWS_AS(eosio::vm::invoke_with_signal_handler([](){
       eosio::vm::throw_<eosio::vm::wasm_exit_exception>( "Exiting" );
-   }, [](int){}), eosio::vm::wasm_exit_exception);
+   }, [](int){}, {}), eosio::vm::wasm_exit_exception);
 }
 
 static volatile sig_atomic_t sig_handled;
@@ -54,9 +54,11 @@ TEST_CASE("Test signal handler forwarding", "[signal_handler_forward]") {
       sig_handled = 0;
       std::raise(SIGSEGV);
       CHECK(sig_handled == 42 + SIGSEGV);
+#ifndef __linux__
       sig_handled = 0;
       std::raise(SIGBUS);
       CHECK(sig_handled == 42 + SIGBUS);
+#endif
       sig_handled = 0;
       std::raise(SIGFPE);
       CHECK(sig_handled == 42 + SIGFPE);
@@ -73,9 +75,11 @@ TEST_CASE("Test signal handler forwarding", "[signal_handler_forward]") {
       sig_handled = 0;
       std::raise(SIGSEGV);
       CHECK(sig_handled == 142 + SIGSEGV);
+#ifndef __linux__
       sig_handled = 0;
       std::raise(SIGBUS);
       CHECK(sig_handled == 142 + SIGBUS);
+#endif
       sig_handled = 0;
       std::raise(SIGFPE);
       CHECK(sig_handled == 142 + SIGFPE);


### PR DESCRIPTION
EOS VM uses page protection for guarding memory accesses and interrupting execution. Currently, when EOS VM starts execution it prepares its signal handler to handle any faults that occur until execution is complete as an `access violation` WASM error. This means both faults that occur inside of WASM execution _and in any host functions that WASM calls_ are all reported and treated as a recoverable `access violation`.

Because EOS VM captures `SIGBUS` (wholly unnecessary on Linux, but needed on macOS) a substantial number of (very much rare corner case, but still very real) unrecoverable system errors occurring in host functions will instead be treated as a recoverable `access violation` as if the WASM simply accessed out of bounds memory in its sandbox. This can include an IO error on the DB file, an IO error when swapping, running out of disk space, an unrecoverable ECC error, running out of free huge pages (in `heap` mode w/ huge pages enabled), and maybe more. These unrecoverable system errors should not be handled as a recoverable WASM memory violation.

Removing `SIGBUS` from being handled on Linux would generally resolve this problem, though if a host function had a defect causing a `SIGSEGV` it would fall in to the same improper handling. So for a more thorough solution, now the signal handler will only handle `SIGSEGV`/`SIGBUS`/`SIGFPE` on given memory ranges -- the WASM code & WASM memory. Faults that occur outside these ranges are forwarded to the next handler (or kill the application if EOS VM's handler is the last chained). This behavior is similar to how EOS VM OC's handler operates. I've also removed `SIGBUS` from being handled on Linux entirely to resolve the exceptionally unlikely scenario of catching an ECC failure inside of WASM memory.

Of course, this means if one of the above system errors are occurring, nodeos will now simply be killed whereas before it'd potentially get stuck in some wedged state that was still cleanly stoppable. While that might sound bad, it's a good thing: we should only be recovering from errors we know we can properly recover from.

This behavior is a theory on AntelopeIO/leap#2242: some fault is masquerading as an `access violation` due to the current greediness of the handlers.