### PR TITLE
`eos_vm` 7% perf improvement by optimizing the  expensive `get_imported_functions_size` function.

### DIFF
--- a/include/eosio/vm/types.hpp
+++ b/include/eosio/vm/types.hpp
@@ -338,7 +338,11 @@ namespace eosio { namespace vm {
       static uint32_t get_imported_functions_size_impl(const Imports& imports) {
          uint32_t number_of_imports = 0;
          const auto sz = imports.size();
-         const auto data = imports.data(); // to avoid the unnecessary size check since we iterate from 0 to sz
+         // we don't want to use `imports[i]` or `imports.at(i)` since these do an unnecessary check
+         // `EOS_VM_ASSERT(i < _size)`. The check is unnecessary since we iterate from `0` to `_size`.
+         // So get the pointer to the first element and dereference it directly.
+         // ------------------------------------------------------------------------------------------------
+         const auto data = imports.data();
          for (uint32_t i = 0; i < sz; i++) {
             if (data[i].kind == external_kind::Function)
                number_of_imports++;

--- a/include/eosio/vm/types.hpp
+++ b/include/eosio/vm/types.hpp
@@ -337,8 +337,10 @@ namespace eosio { namespace vm {
       template<typename Imports>
       static uint32_t get_imported_functions_size_impl(const Imports& imports) {
          uint32_t number_of_imports = 0;
-         for (uint32_t i = 0; i < imports.size(); i++) {
-            if (imports[i].kind == external_kind::Function)
+         const auto sz = imports.size();
+         const auto data = imports.data(); // to avoid the unnecessary size check since we iterate from 0 to sz
+         for (uint32_t i = 0; i < sz; i++) {
+            if (data[i].kind == external_kind::Function)
                number_of_imports++;
          }
          return number_of_imports;

--- a/include/eosio/vm/wasm_stack.hpp
+++ b/include/eosio/vm/wasm_stack.hpp
@@ -34,7 +34,7 @@ namespace eosio { namespace vm {
             if (_index >= _store.size())
                _store.resize(_store.size()*2);
          }
-         _store[_index++] = std::forward<ElemT>(e);
+         _store[_index++] = std::move(e);
       }
 
       ElemT pop() { return _store[--_index]; }


### PR DESCRIPTION
This improves the performance of `eos-vm` by about 7%  (reduces total time from 6.8% to 1.55%, however the time spent in `execute` is 75% of the total execution time for `api_part2_tests`).

Running the perf tool, I noticed that `get_imported_functions_size`  was one of the top cpu users. Most of the time is spent calling `size()` and doing an unnecessary check (that `_index`, the `i` in the loop, is less than size()).

This streamlines the code. 

**pre optimization:**

![pre_optim](https://github.com/user-attachments/assets/cdd6aed3-fb19-479f-9442-c13dd64a8b38)

**post optimization:**

![post_optim](https://github.com/user-attachments/assets/ea9e1904-904b-4c4f-bc87-c471579a6966)



Also fixes an incorrect `std::forward` use, of no consequense since the forwarded data has no pointers and is moved anyways.