### PR TITLE
[spring 1.0] avoid spurious access violation on thread due to other timed out thread

### DIFF
--- a/include/eosio/vm/execution_context.hpp
+++ b/include/eosio/vm/execution_context.hpp
@@ -358,11 +358,11 @@ namespace eosio { namespace vm {
 
                   vm::invoke_with_signal_handler([&]() {
                      result = execute<sizeof...(Args)>(args_raw, fn, this, base_type::linear_memory(), stack);
-                  }, &handle_signal, {_mod->allocator.get_code_span(),  base_type::get_wasm_allocator()->get_span()});
+                  }, &handle_signal, _mod->allocator, base_type::get_wasm_allocator());
                } else {
                   vm::invoke_with_signal_handler([&]() {
                      result = execute<sizeof...(Args)>(args_raw, fn, this, base_type::linear_memory(), stack);
-                  }, &handle_signal, {_mod->allocator.get_code_span(),  base_type::get_wasm_allocator()->get_span()});
+                  }, &handle_signal, _mod->allocator, base_type::get_wasm_allocator());
                }
             }
          } catch(wasm_exit_exception&) {
@@ -800,7 +800,7 @@ namespace eosio { namespace vm {
             setup_locals(func_index);
             vm::invoke_with_signal_handler([&]() {
                execute(visitor);
-            }, &handle_signal, {_mod->allocator.get_code_span(),  base_type::get_wasm_allocator()->get_span()});
+            }, &handle_signal, _mod->allocator, base_type::get_wasm_allocator());
          }
 
          if (_mod->get_function_type(func_index).return_count && !_state.exiting) {

--- a/tests/signals_tests.cpp
+++ b/tests/signals_tests.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Testing signals", "[invoke_with_signal_handler]") {
          std::raise(SIGSEGV);
       }, [](int sig) {
          throw test_exception{};
-      }, {});
+      }, {}, {});
    } catch(test_exception&) {
       okay = true;
    }
@@ -25,7 +25,7 @@ TEST_CASE("Testing signals", "[invoke_with_signal_handler]") {
 TEST_CASE("Testing throw", "[signal_handler_throw]") {
    CHECK_THROWS_AS(eosio::vm::invoke_with_signal_handler([](){
       eosio::vm::throw_<eosio::vm::wasm_exit_exception>( "Exiting" );
-   }, [](int){}, {}), eosio::vm::wasm_exit_exception);
+   }, [](int){}, {}, {}), eosio::vm::wasm_exit_exception);
 }
 
 static volatile sig_atomic_t sig_handled;


### PR DESCRIPTION
(At least with how spring uses EOS VM) all executing threads share the same executable pages. This causes a conflict when one executing thread enters a time out condition because a time out sets the pages to non-executable which forces execution to stop not just on the timed out thread but on all executing threads. The non-timed out threads will consider this failure an access violation because since they weren't expecting a time out the failure is assumed to be due to accessing invalid wasm memory (etc).

One way to resolve this is by having each thread maintain its own EOS VM "instance", but we have expressly avoided that in spring to avoid re-compiling contracts (and incurring all that overhead) on each thread; for which there can be many. Another way to resolve this is by each thread maintaining its own mapping of shared compilation memory, similar to how EOS VM OC works. But unfortunately that feels like quite a refactor in the current design.

The approach this PR takes is to, upon signal delivery, identify if the access violation was in the code pages and if so check a thread local boolean that indicates whether the `timed_run` is timed out or not. If this boolean is false _any access violation within the code pages in this thread must have been due to a different thread timing out_, so the faulting thread simply keeps retrying to execute since the different thread's `timed_run` will eventually reset the memory accordingly.

The nice thing about this approach is that it actually ends up being a fairly small change. The down side is that the non-timed out threads will enter a "SEGV storm" for a tiny period of time before the timed out thread's `timed_run` restores permissions. That doesn't feel like a deal breaker though. But the approach does introduce a layering violation between `timed_run` and signal handling code due to the use of a global thread local, which is unfortunate.