### PR TITLE
fix standalone cmake file when `ENABLE_TESTS=On`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,7 +113,6 @@ add_executable(unit_tests main.cpp
                           null_tests.cpp
                           reentry_tests.cpp
                           signals_tests.cpp
-                          span_tests.cpp
                           stack_restriction_tests.cpp
                           watchdog_tests.cpp
                           implementation_limits_tests.cpp


### PR DESCRIPTION
`span_tests.cpp` was removed in #29 so it should have been removed from cmake too.