### PR TITLE
expect `SIGBUS` for `PROT_NONE` access on macOS/*BSD due to overlapped timer

### DIFF
--- a/include/eosio/vm/signals.hpp
+++ b/include/eosio/vm/signals.hpp
@@ -52,12 +52,8 @@ namespace eosio { namespace vm {
             //a SEGV/BUS in the code range when timed_run_has_timed_out=false is due to a _different_ thread's execution activating a deadline
             // timer. Return and retry executing the same code again. Eventually timed_run() on the other thread will reset the page
             // permissions and progress on this thread can continue
-#ifdef __linux__
-            const int sig_on_prot_none_access = SIGSEGV;
-#else  //macos, *bsd
-            const int sig_on_prot_none_access = SIGBUS;
-#endif
-            if (sig == sig_on_prot_none_access && timed_run_has_timed_out.load(std::memory_order_acquire) == false)
+            //on linux no SIGBUS handler is registered (see setup_signal_handler_impl()) so it will never occur here
+            if ((sig == SIGSEGV || sig == SIGBUS) && timed_run_has_timed_out.load(std::memory_order_acquire) == false)
                return;
             //otherwise, jump out
             siglongjmp(*dest, sig);


### PR DESCRIPTION
As I suspected at https://github.com/AntelopeIO/eos-vm/pull/30#discussion_r1924232062, now that I have my x86 macOS box updated so I can run latest XCode, indeed this needs to be a `SIGBUS`