### PR TITLE
SC: Add destructor to wasm_allocator to release memory

### DIFF
--- a/include/eosio/vm/allocator.hpp
+++ b/include/eosio/vm/allocator.hpp
@@ -488,6 +488,11 @@ namespace eosio { namespace vm {
          raw += syspagesize;
          page = 0;
       }
+      ~wasm_allocator() {
+         if (raw) {
+            free();
+         }
+      }
       // Initializes the memory controlled by the allocator.
       //
       // \post get_current_page() == new_pages


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
`wasm_allocator` did not implement destructors, and memory it allocated was not released. It caused memory exhaustion when running unit_test.

The PR adds a destructor.

Resolves https://github.com/AntelopeIO/spring/issues/1407

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
