### PR TITLE
be more specific when using `vm::module` to avoid confusion as a C++20 `module`

### DIFF
--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -173,7 +173,7 @@ namespace eosio { namespace vm {
             // First pass: finds max size of memory required by parsing.
             {
                // Memory used by this pass is freed when going out of the scope
-               module first_pass_module;
+               vm::module first_pass_module;
                first_pass_module.allocator.use_default_memory();
                parser_t{ first_pass_module.allocator, options }.parse_module2(ptr, sz, first_pass_module, debug);
                first_pass_module.finalize();


### PR DESCRIPTION
With gcc15 it is possible to end up with errors such as
```
In file included from spring.libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp:12,
                 from spring/libraries/chain/include/eosio/chain/webassembly/preconditions.hpp:5,
                 from spring/libraries/chain/webassembly/softfloat.cpp:2:
spring/libraries/eos-vm/include/eosio/vm/backend.hpp:176:16: error: module control-line cannot be in included file
  176 |                module first_pass_module;
      |                ^~~~~~
```
This seems to be enough to rectify the problem from what I've seen so far