### PR TITLE
SC: Make timed_run() a unified templated function for void and non-void return types

### DIFF
--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -21,6 +21,7 @@
 #include <string_view>
 #include <system_error>
 #include <vector>
+#include <type_traits>
 
 namespace eosio { namespace vm {
 
@@ -304,7 +305,7 @@ namespace eosio { namespace vm {
       }
 
       template<typename Watchdog, typename F>
-      inline void timed_run(Watchdog&& wd, F&& f) {
+      inline auto timed_run(Watchdog&& wd, F&& f) {
          //timed_run_has_timed_out -- declared in signal handling code because signal handler needs to inspect it on a SEGV too -- is a thread local
          // so that upon a SEGV the signal handling code can discern if the thread that caused the SEGV has a timed_run that has timed out. This
          // thread local also need to be an atomic because the thread that a Watchdog callback will be called from may not be the same as the
@@ -321,7 +322,13 @@ namespace eosio { namespace vm {
                _timed_out.store(true, std::memory_order_release);
                mod->allocator.disable_code();
             });
-            std::forward<F>(f)();
+
+            using return_type = std::invoke_result_t<F>;
+            if constexpr (std::is_void_v<return_type>) {
+               std::forward<F>(f)();
+            } else {
+               return std::forward<F>(f)();
+            }
          } catch(wasm_memory_exception&) {
             if (_timed_out.load(std::memory_order_acquire)) {
                throw timeout_exception{ "execution timed out" };

--- a/include/eosio/vm/backend.hpp
+++ b/include/eosio/vm/backend.hpp
@@ -21,7 +21,6 @@
 #include <string_view>
 #include <system_error>
 #include <vector>
-#include <type_traits>
 
 namespace eosio { namespace vm {
 
@@ -322,13 +321,7 @@ namespace eosio { namespace vm {
                _timed_out.store(true, std::memory_order_release);
                mod->allocator.disable_code();
             });
-
-            using return_type = std::invoke_result_t<F>;
-            if constexpr (std::is_void_v<return_type>) {
-               std::forward<F>(f)();
-            } else {
-               return std::forward<F>(f)();
-            }
+            return std::forward<F>(f)();
          } catch(wasm_memory_exception&) {
             if (_timed_out.load(std::memory_order_acquire)) {
                throw timeout_exception{ "execution timed out" };


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
`timed_run()` is used in Spring for executing `apply()` and `sync_call()` entry points. `apply()` is a `void` while `sync_call()` returns `int64_t`.

With C++ template function traits, it is elegant to make a single `timed_run()` for both void and non-void return types.

Resolves https://github.com/AntelopeIO/eos-vm/issues/41

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
